### PR TITLE
Fix get/set speed of purifier for new models.

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -61,6 +61,11 @@
                             "type": "boolean",
                             "description": "Does this device support 'sleep' speed?"
                         },
+                        "new_model": {
+                            "title": "Newer model",
+                            "type": "boolean",
+                            "description": "Do you have newer model?"
+                        },
                         "light_control": {
                             "title": "Light Control",
                             "type": "boolean",

--- a/src/configTypes.ts
+++ b/src/configTypes.ts
@@ -1,9 +1,12 @@
 export type PhilipsAirPlatformConfig = {
   name: string;
   timeout_seconds: number;
-  old_speed: number;
   devices: Array<DeviceConfig>
 };
+
+export type PhilipsAirPlatform = {
+    old_speed: number;
+}
 
 export type DeviceConfig = {
   name: string;

--- a/src/configTypes.ts
+++ b/src/configTypes.ts
@@ -9,6 +9,6 @@ export type DeviceConfig = {
   ip: string;
   protocol: string;
   sleep_speed: boolean;
-  newer_model: boolean;
+  new_model: boolean;
   light_control: boolean;
 };

--- a/src/configTypes.ts
+++ b/src/configTypes.ts
@@ -9,5 +9,6 @@ export type DeviceConfig = {
   ip: string;
   protocol: string;
   sleep_speed: boolean;
+  newer_model: boolean;
   light_control: boolean;
 };

--- a/src/configTypes.ts
+++ b/src/configTypes.ts
@@ -1,6 +1,7 @@
 export type PhilipsAirPlatformConfig = {
   name: string;
   timeout_seconds: number;
+  old_speed: number;
   devices: Array<DeviceConfig>
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -401,6 +401,10 @@ class PhilipsAirPlatform implements DynamicPlatformPlugin {
         offset = 1;
       }
       const speed = Math.ceil(state as number / divisor);
+
+      if(!!this.old_speed && this.old_speed == speed ) return;
+      this.old_speed = speed;
+
       if (speed > 0) {
         const values = {
           mode: '',

--- a/src/index.ts
+++ b/src/index.ts
@@ -197,7 +197,7 @@ class PhilipsAirPlatform implements DynamicPlatformPlugin {
 
           let speed = 0;
           if (status.pwr == '1') {
-            if (!mode) {
+            if (!mode || purifier.config.new_model) {
               if (status.om == 't') {
                 speed = 100;
               } else if (status.om == 's') {
@@ -403,15 +403,18 @@ class PhilipsAirPlatform implements DynamicPlatformPlugin {
       const speed = Math.ceil(state as number / divisor);
       if (speed > 0) {
         const values = {
-          mode: 'M',
+          mode: '',
           om: ''
         };
         if (offset == 1 && speed == 1) {
           values.om = 's';
+          values.mode = (purifier.config.new_model) ? 'S':'M';
         } else if (speed < 4 + offset) {
           values.om = (speed - offset).toString();
+          values.mode = (purifier.config.new_model) ? 'A':'M';
         } else {
           values.om = 't';
+          values.mode = (purifier.config.new_model) ? 'T':'M';
         }
 
         try {


### PR DESCRIPTION
This fixes issue #85 for newer models. Newer models don't have mode `M`, but they have modes `A`, `S`, `T` for modes Auto, Sleep, Turbo. For backward compatibility, I've created new config option, which will be by default unchecked.